### PR TITLE
changed detectURLChangeAndInjectDate definition, fixes #1

### DIFF
--- a/src/inject-date.js
+++ b/src/inject-date.js
@@ -10,17 +10,17 @@ if (window.location.pathname.split("/").length === 2) {
 
 // history API cannot be used directly in content-scripts
 function detectURLChangeAndInjectDate(apparentUsername) {
-  setInterval(
-    () => {
-      const leftPane = getLeftPane();
-      const lastElementInPane = getLastInPane(leftPane);
- 
-      if (typeof lastElementInPane === "undefined" || lastElementInPane.getAttribute("aria-label") !== "createdAt") {
-            injectCreationDate(apparentUsername);
-      }
-    },
-    1000
-  );
+  setInterval(() => {
+    const leftPane = getLeftPane();
+    const lastElementInPane = getLastInPane(leftPane);
+
+    if (
+      typeof lastElementInPane === "undefined" ||
+      lastElementInPane.getAttribute("aria-label") !== "createdAt"
+    ) {
+      injectCreationDate(apparentUsername);
+    }
+  }, 1000);
 }
 
 async function injectCreationDate(apparentUsername) {
@@ -39,10 +39,9 @@ async function injectCreationDate(apparentUsername) {
     const lastElementInPane = getLastInPane(leftPane);
 
     if (
-        typeof lastElementInPane === "undefined" ||
-        lastElementInPane.getAttribute("aria-label") !== "createdAt"
+      typeof lastElementInPane === "undefined" ||
+      lastElementInPane.getAttribute("aria-label") !== "createdAt"
     ) {
-      
       const dateElement = document.createElement("li");
       dateElement.innerText = creationDate;
       dateElement.setAttribute(
@@ -57,13 +56,11 @@ async function injectCreationDate(apparentUsername) {
 }
 
 function getLeftPane() {
-    return document.querySelector(
-      "#js-pjax-container > div > div.col-3.float-left.pr-3 > ul"
-    );
+  return document.querySelector(
+    "#js-pjax-container > div > div.col-3.float-left.pr-3 > ul"
+  );
 }
 
 function getLastInPane(leftPane) {
-    return Array.from(
-      leftPane.getElementsByTagName("li")
-    ).pop();
+  return Array.from(leftPane.getElementsByTagName("li")).pop();
 }

--- a/src/inject-date.js
+++ b/src/inject-date.js
@@ -10,11 +10,13 @@ if (window.location.pathname.split("/").length === 2) {
 
 // history API cannot be used directly in content-scripts
 function detectURLChangeAndInjectDate(apparentUsername) {
-  let currentURL = window.location.href;
   setInterval(
     () => {
-      if (currentURL !== window.location.href) {
-        injectCreationDate(apparentUsername);
+      const leftPane = getLeftPane();
+      const lastElementInPane = getLastInPane(leftPane);
+ 
+      if (typeof lastElementInPane === "undefined" || lastElementInPane.getAttribute("aria-label") !== "createdAt") {
+            injectCreationDate(apparentUsername);
       }
     },
     1000
@@ -33,17 +35,14 @@ async function injectCreationDate(apparentUsername) {
       .slice(1, 4)
       .join(" ");
 
-    const leftPane = document.querySelector(
-      "#js-pjax-container > div > div.col-3.float-left.pr-3 > ul"
-    );
+    const leftPane = getLeftPane();
+    const lastElementInPane = getLastInPane(leftPane);
 
-    const lastElementInPane = Array.from(
-      leftPane.getElementsByTagName("li")
-    ).pop();
     if (
-      typeof lastElementInPane === "undefined" ||
-      lastElementInPane.getAttribute("aria-label") !== "createdAt"
+        typeof lastElementInPane === "undefined" ||
+        lastElementInPane.getAttribute("aria-label") !== "createdAt"
     ) {
+      
       const dateElement = document.createElement("li");
       dateElement.innerText = creationDate;
       dateElement.setAttribute(
@@ -55,4 +54,16 @@ async function injectCreationDate(apparentUsername) {
       leftPane.appendChild(dateElement);
     }
   }
+}
+
+function getLeftPane() {
+    return document.querySelector(
+      "#js-pjax-container > div > div.col-3.float-left.pr-3 > ul"
+    );
+}
+
+function getLastInPane(leftPane) {
+    return Array.from(
+      leftPane.getElementsByTagName("li")
+    ).pop();
 }


### PR DESCRIPTION
The reason why it worked on reload and not before that on **Overview** tab was that:

- Overview tab had url _https://github.com/<username\>_
- The way the function was written, it kept the `currentURL` value the same, i.e. _https://github.com/<username\>_

That is why it never fulfilled the condition `if (currentURL !== window.location.href)` and `injectCreationDate()` never got called.


Please take a look at this implementation. It does nothing but check if the `leftPane` has the date `<li>`, and if not, it calls `injectCreationDate()`

If you think it is an appropriate solution, merge it. If you think it is not, mention why, so I can better understand it and improve my implementation. 